### PR TITLE
Add command to generate shell completion scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Shell completion
 - Updated to Rust 2021
 
 ## [1.0.0] - 2021-08-27

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +540,7 @@ dependencies = [
  "bencher",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "dirs",
  "predicates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ pre-release-replacements = [
 
 [dependencies]
 clap = { version = "3.2.8", features = ["cargo", "derive"] }
+clap_complete = "3.2.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ To get an equivalent prompt with "Oh my Posh", use the following `segement` code
 }
 ```
 
+### Completion
+
+Use the `completion` command to generate the completion script for your shell. 
+See `trackie completion --help` for details.
+
+Exemple with zsh:
+
+```zsh
+trackie completion zsh > /usr/local/share/zsh/site-functions/_trackie 
+```
+
+> **Note** 
+> Make sure to restart your shell for the changes to take effect
+
+
 ## Installation
 
 #### Download prebuilt release

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{crate_authors, crate_version, Parser};
+use clap_complete::Shell;
 
 pub const DEFAULT_STATUS_FORMAT: &str = "Tracking %p since %d (%t) [%D]";
 pub const DEFAULT_EMPTY_STATUS_MSG: &str = "Currently tracking no project.";
@@ -31,8 +32,16 @@ pub enum Subcommand {
     #[clap(verbatim_doc_comment)]
     Status(StatusCommand),
     /// Resumes time tracking for the last tracked project.
-    #[clap(visible_alias="rs")]
+    #[clap(visible_alias = "rs")]
     Resume(EmptyCommand),
+    /// Generate tab-completion scripts for your shell
+    Completion(CompletionCommand),
+}
+
+#[derive(Parser)]
+pub struct CompletionCommand {
+    #[clap(value_parser)]
+    pub shell: Shell,
 }
 
 #[derive(Parser)]
@@ -67,5 +76,5 @@ pub struct ReportCommand {
 
     /// Dump report as JSON
     #[clap(long)]
-    pub json: bool
+    pub json: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,19 @@ use std::error::Error;
 use chrono::Local;
 
 use crate::cli::{
-    Opts, Subcommand, TimingCommand, DEFAULT_EMPTY_STATUS_MSG, DEFAULT_STATUS_FORMAT,
+    CompletionCommand, Opts, Subcommand, TimingCommand, DEFAULT_EMPTY_STATUS_MSG,
+    DEFAULT_STATUS_FORMAT,
 };
 use crate::persistence::{load_or_create_log, save_log, FileHandler};
 use crate::pretty_string::PrettyString;
 use crate::report_creator::ReportCreator;
 use crate::time_log::TimeLog;
+use clap::{Command, CommandFactory};
+use clap_complete::{generate, Generator};
 use colored::Colorize;
 use std::fmt::Display;
 use std::fmt::Formatter;
+use std::io;
 
 pub mod cli;
 pub mod persistence;
@@ -88,6 +92,10 @@ pub fn run_app(o: Opts, fh: &mut dyn FileHandler) -> Result<(), TrackieError> {
                 ));
             }
         },
+        Subcommand::Completion(CompletionCommand { shell }) => {
+            let mut cmd = Opts::command();
+            print_completions(shell, &mut cmd);
+        }
     }
 
     if modified {
@@ -106,6 +114,10 @@ fn start_tracking(log: &mut TimeLog, p: TimingCommand) -> Result<(), Box<dyn Err
         p.project_name.as_str().italic()
     );
     Ok(())
+}
+
+fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
+    generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
 }
 
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,8 +157,11 @@ impl Error for TrackieError {}
 
 #[cfg(test)]
 mod tests {
+    use clap_complete::Shell;
+
     use crate::cli::{
-        EmptyCommand, Opts, StatusCommand, Subcommand, TimingCommand, DEFAULT_EMPTY_STATUS_MSG,
+        CompletionCommand, EmptyCommand, Opts, StatusCommand, Subcommand, TimingCommand,
+        DEFAULT_EMPTY_STATUS_MSG,
     };
     use crate::persistence::FileHandler;
     use crate::run_app;
@@ -335,6 +338,18 @@ mod tests {
         );
 
         assert!(second_stop.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn generate_completion() -> Result<(), Box<dyn Error>> {
+        let mut handler = TestFileHandler::default();
+        run_app(
+            Opts {
+                sub_cmd: Subcommand::Completion(CompletionCommand { shell: Shell::Bash }),
+            },
+            &mut handler,
+        )?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR adds a `completion` command to generate shell completion script #77
It uses the [clap built-in way](https://github.com/clap-rs/clap/tree/master/clap_complete) to do so.  

Also, I don't think there's a straightforward way to complete _projects_ yet. See https://github.com/clap-rs/clap/issues/1232

Example for zsh:
```zsh
trackie completion zsh > /usr/local/share/zsh/site-functions/_trackie
```


## Pull request checklist

- [ ] The tests are passing locally as well as on CI
- [ ] The changelog was updated (in `CHANGELOG.md`)
- [ ] If commands were added/modified, the documentation was adapted
